### PR TITLE
Moved to Bean styled WebClient for distributed tracing.

### DIFF
--- a/src/main/java/com/two/http_api/WebClientBeanConfiguration.java
+++ b/src/main/java/com/two/http_api/WebClientBeanConfiguration.java
@@ -1,0 +1,18 @@
+package com.two.http_api;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Scope;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientBeanConfiguration {
+
+    @Bean
+    @Primary
+    public WebClient getWebClient() {
+        return WebClient.create();
+    }
+
+}


### PR DESCRIPTION
- Allows Sleuth to pickup the WebClient and attach tracing headers
- Removed helper method to retrieve Eureka service IP
- Users service is not currently used, so did not update.